### PR TITLE
fix: tickers from pandas

### DIFF
--- a/tikers/encode_jp.py
+++ b/tikers/encode_jp.py
@@ -7,13 +7,9 @@ df = pd.read_excel("./tikers/jp.xls", usecols=["コード", "銘柄名", "市場
 # # 項目名を変更
 df.columns = ["ticker", "foundname", "market"]
 
-# tickerの値を判断する関数作成
-def ticker_check(row):
-    ticker = str(row["ticker"]) + ".T"
-    return str(ticker)
-
-# # 各行のticker欄に、↑の関数で処理
-df["ticker"] = df.apply(ticker_check, axis=1)
+# tickerにある全データを文字列に変換し、文字列を1個ずつ小数点があった場合は区切って
+# 最初の4文字を.Tと結合 (ifで1個ずつ判定するより効率的+)
+df["ticker"] = df["ticker"].astype(str).str.split(".").str[0] + ".T"
 
 data_to_insert = list(zip(df["ticker"], df["foundname"], df["market"]))
 


### PR DESCRIPTION
#### 銘柄コードのautoComplete機能が動作しない不具合を修正
***
##### bugの原因は恐らく
```
① data型の不一致: Excelのコード欄に純粋な数値（例: 1301）と、数値+文字（例: 326A）が混在。
② 意図しない型変換: pandasが純粋な数値をに浮動小数点数（float型）に変換してしまったかもしれない。（例: 1301 → 1301.0）
③ ticker変換: 修正前のコードは、この 1301.0 をそのまま文字列に変換し .T を結合したため、"1301.0.T" というtickerが生成される。
④ APIエラー: 予想外のtikcerで、yfinanceライブラリから情報を取得できず、結果autoComplete機能が停止。
```
***
##### 解決
integer → float 変換されても対応できるように、  
pandasのastype関数で全データを文字列化、文字列に.が含まれる場合区切りとして分割、  
最終的に `先頭4文字 + .T`の形式で正しいtickerを作成。
```
例：
df["ticker"] = df["ticker"].astype(str).str.split(".").str[0] + ".T"
```
  
| ![](https://i.ibb.co/GQHq6SYb/bug.gif) | ![](https://i.ibb.co/W4C5jb78/fixed.gif)  | 
|:-----------:|:------------:|
|修正前|修正後|
